### PR TITLE
Change the PostBuildEvent to use the AssemblyName

### DIFF
--- a/src/MockMe/Build/MockMe.targets
+++ b/src/MockMe/Build/MockMe.targets
@@ -21,6 +21,6 @@
   <!--<UsingTask TaskName="MockMe.Build.ReplaceGenericMethods" AssemblyFile="$(MockMeAssembly)" />-->
 
   <Target Name="ReplaceGenericMethods" AfterTargets="PostBuildEvent">
-    <Exec Command='dotnet --roll-forward Major "$(MockMePath)MockMe.PostBuild.dll" "$(MSBuildProjectDirectory)\$(OutputPath)$(ProjectName).dll"' />
+    <Exec Command='dotnet --roll-forward Major "$(MockMePath)MockMe.PostBuild.dll" "$(MSBuildProjectDirectory)\$(OutputPath)$(AssemblyName).dll"' />
   </Target>
 </Project>


### PR DESCRIPTION
The projectname can differ from the assemblyname.

Solves #30 