### PR TITLE
Fix code generation for interfaces inheriting from other interfaces

### DIFF
--- a/src/MockMe.Generator/MockGenerators/TypeGenerators/InterfaceMockGenerator.cs
+++ b/src/MockMe.Generator/MockGenerators/TypeGenerators/InterfaceMockGenerator.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using MockMe.Generator.Extensions;
@@ -7,8 +8,13 @@ namespace MockMe.Generator.MockGenerators.TypeGenerators;
 internal class InterfaceMockGenerator(INamedTypeSymbol typeSymbol, string typeName)
     : MockGeneratorBase(typeSymbol, typeName)
 {
+    // Gather all interfaces, including inherited ones, and ensure distinct results
     public override string GetCallTrackerBaseClass(ITypeSymbol typeSymbol) =>
-        typeSymbol.ToFullTypeString();
+        typeSymbol.AllInterfaces
+            .Concat(new[] { typeSymbol })
+            .Distinct(SymbolEqualityComparer.Default)
+            .Select(i => i?.ToFullTypeString() ?? "")
+            .Aggregate((current, next) => $"{current}, {next}");
 
     public override string GetConstructorAndProps(ITypeSymbol typeSymbol) =>
         @$"

--- a/tests/MockMe.Tests.ExampleClasses/Interfaces/ICalculator.cs
+++ b/tests/MockMe.Tests.ExampleClasses/Interfaces/ICalculator.cs
@@ -1,12 +1,30 @@
 namespace MockMe.Tests.ExampleClasses.Interfaces
 {
-    public interface ICalculator
+    public interface IAddition
+    {
+        int Add(int x, int y);
+    }
+
+    public interface ISubtraction
+    {
+        int Subtract(int a, int b);
+    }
+
+    public interface IMultiplication
+    {
+        double Multiply(double x, double y);
+    }
+
+    public interface IDivision
+    {
+        int Divide(int a, int b);
+    }
+
+    public interface ICalculator : IAddition, ISubtraction, IMultiplication, IDivision
     {
         CalculatorType CalculatorType { get; set; }
-        int Add(int x, int y);
         void DivideByZero(double numToDivide);
         bool IsOn();
-        double Multiply(double x, double y);
         void TurnOff();
     }
 }

--- a/tests/MockMe.Tests/InheritanceTests.cs
+++ b/tests/MockMe.Tests/InheritanceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using MockMe.Tests.ExampleClasses.Interfaces;
 using Xunit;
 
 namespace MockMe.Tests
@@ -59,6 +60,22 @@ namespace MockMe.Tests
             ChildClass notMocked = new();
 
             Assert.Equal(55, notMocked.Return55FromChildMethodOverride());
+        }
+
+        [Fact]
+        public void ICalculator_ShouldImplementAllInterfaceMethods()
+        {
+            var calculatorMock = Mock.Me(default(ICalculator));
+
+            calculatorMock.Setup.Add(Arg.Any(), Arg.Any()).Returns(args => args.x + args.y);
+            calculatorMock.Setup.Subtract(Arg.Any(), Arg.Any()).Returns(args => args.a - args.b);
+            calculatorMock.Setup.Multiply(Arg.Any(), Arg.Any()).Returns(args => args.x * args.y);
+            calculatorMock.Setup.Divide(Arg.Any(), Arg.Any()).Returns(args => args.a / args.b);
+
+            Assert.Equal(4, calculatorMock.MockedObject.Add(2, 2));
+            Assert.Equal(2, calculatorMock.MockedObject.Subtract(4, 2));
+            Assert.Equal(4, calculatorMock.MockedObject.Multiply(2, 2));
+            Assert.Equal(2, calculatorMock.MockedObject.Divide(4, 2));
         }
     }
 }


### PR DESCRIPTION
### Context
This pull request addresses an issue in the code generation process for interfaces that inherit from other interfaces. The current implementation does not generate the code for the inherited interfaces. 

### Changes Made
- Update the code generator to properly recognize and process inherited interfaces.
- Add unit test to validate the changes.