### PR TITLE
Fix code generation for interfaces with overloaded methods

### DIFF
--- a/src/MockMe.Generator/Extensions/MethodSymbolExtensions.cs
+++ b/src/MockMe.Generator/Extensions/MethodSymbolExtensions.cs
@@ -128,12 +128,26 @@ public static class MethodSymbolExtensions
     }
 
     public static string GetUniqueMethodName(this IMethodSymbol methodSymbol)
+        => GenerateUniqueName(methodSymbol, false);
+    public static string GetUniqueStoreName(this IMethodSymbol methodSymbol)
+        => GenerateUniqueName(methodSymbol, true);
+
+    private static string GenerateUniqueName(IMethodSymbol methodSymbol, bool includeContainingType)
     {
         var methodName = methodSymbol.Name;
-        var parameterTypes = methodSymbol.Parameters.Select(p =>
+        var parameterTypes = string.Join("_", methodSymbol.Parameters.Select(p =>
             (p.RefKind == RefKind.None ? "" : p.RefKind.ToString()) + p.Type.Name
-        );
-        var uniqueMethodName = $"{methodName}_{string.Join("_", parameterTypes)}";
-        return uniqueMethodName;
+        ));
+        if (!includeContainingType)
+        {
+            return $"{methodName}_{parameterTypes}";
+        }
+
+        var containingType = methodSymbol.ContainingType?.Name ?? "global";
+        var accessModifier = methodSymbol.DeclaredAccessibility;
+        var returnType = methodSymbol.ReturnType.Name;
+        var typeParameters = string.Join("_", methodSymbol.TypeParameters.Select(tp => tp.Name));
+
+        return $"{containingType}_{accessModifier}_{returnType}_{methodName}_{typeParameters}_{parameterTypes}";
     }
 }

--- a/src/MockMe.Generator/MockGenerators/MethodGenerators/MethodMockGeneratorBase.cs
+++ b/src/MockMe.Generator/MockGenerators/MethodGenerators/MethodMockGeneratorBase.cs
@@ -171,9 +171,9 @@ internal abstract class MethodMockGeneratorBase
         return this.methodSymbol.GetUniqueMethodName() + "Collection";
     }
 
-    protected string GetBagStoreName() => this.methodSymbol.GetUniqueMethodName() + "BagStore";
+    protected string GetBagStoreName() => this.methodSymbol.GetUniqueStoreName() + "BagStore";
 
-    protected string GetCallStoreName() => this.methodSymbol.GetUniqueMethodName() + "CallStore";
+    protected string GetCallStoreName() => this.methodSymbol.GetUniqueStoreName() + "CallStore";
 
     protected string GetSetupMethod()
     {

--- a/src/MockMe.Generator/MockGenerators/TypeGenerators/InterfaceMockGenerator.cs
+++ b/src/MockMe.Generator/MockGenerators/TypeGenerators/InterfaceMockGenerator.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using MockMe.Generator.Extensions;
@@ -7,8 +8,13 @@ namespace MockMe.Generator.MockGenerators.TypeGenerators;
 internal class InterfaceMockGenerator(INamedTypeSymbol typeSymbol, string typeName)
     : MockGeneratorBase(typeSymbol, typeName)
 {
+    // Gather all interfaces, including inherited ones, and ensure distinct results
     public override string GetCallTrackerBaseClass(ITypeSymbol typeSymbol) =>
-        typeSymbol.ToFullTypeString();
+        typeSymbol.AllInterfaces
+            .Concat(new[] { typeSymbol })
+            .Distinct(SymbolEqualityComparer.Default)
+            .Select(i => i?.ToFullTypeString() ?? "")
+            .Aggregate((current, next) => $"{current}, {next}");
 
     public override string GetConstructorAndProps(ITypeSymbol typeSymbol) =>
         @$"

--- a/tests/MockMe.Tests.ExampleClasses/Interfaces/ICalculator.cs
+++ b/tests/MockMe.Tests.ExampleClasses/Interfaces/ICalculator.cs
@@ -1,12 +1,30 @@
 namespace MockMe.Tests.ExampleClasses.Interfaces
 {
-    public interface ICalculator
+    public interface IAddition
+    {
+        int Add(int x, int y);
+    }
+
+    public interface ISubtraction
+    {
+        int Subtract(int a, int b);
+    }
+
+    public interface IMultiplication
+    {
+        double Multiply(double x, double y);
+    }
+
+    public interface IDivision
+    {
+        int Divide(int a, int b);
+    }
+
+    public interface ICalculator : IAddition, ISubtraction, IMultiplication, IDivision
     {
         CalculatorType CalculatorType { get; set; }
-        int Add(int x, int y);
         void DivideByZero(double numToDivide);
         bool IsOn();
-        double Multiply(double x, double y);
         void TurnOff();
     }
 }

--- a/tests/MockMe.Tests.ExampleClasses/Interfaces/ICalculator.cs
+++ b/tests/MockMe.Tests.ExampleClasses/Interfaces/ICalculator.cs
@@ -1,5 +1,21 @@
 namespace MockMe.Tests.ExampleClasses.Interfaces
 {
+    public interface ISymbolVisitor
+    {
+        void VisitAddition(IAddition addition);
+        void VisitSubtraction(ISubtraction subtraction);
+        void VisitMultiplication(IMultiplication multiplication);
+        void VisitDivision(IDivision division);
+    }
+
+    public interface ISymbolVisitor<out T>
+    {
+        T VisitAddition(IAddition addition);
+        T VisitSubtraction(ISubtraction subtraction);
+        T VisitMultiplication(IMultiplication multiplication);
+        T VisitDivision(IDivision division);
+    }
+
     public interface IAddition
     {
         int Add(int x, int y);
@@ -26,5 +42,8 @@ namespace MockMe.Tests.ExampleClasses.Interfaces
         void DivideByZero(double numToDivide);
         bool IsOn();
         void TurnOff();
+
+        void Accept(ISymbolVisitor visitor);
+        T Accept<T>(ISymbolVisitor<T> visitor);
     }
 }

--- a/tests/MockMe.Tests/InheritanceTests.cs
+++ b/tests/MockMe.Tests/InheritanceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using MockMe.Tests.ExampleClasses.Interfaces;
 using Xunit;
 
 namespace MockMe.Tests
@@ -59,6 +60,22 @@ namespace MockMe.Tests
             ChildClass notMocked = new();
 
             Assert.Equal(55, notMocked.Return55FromChildMethodOverride());
+        }
+
+        [Fact]
+        public void ICalculator_ShouldImplementAllInterfaceMethods()
+        {
+            var calculatorMock = Mock.Me(default(ICalculator));
+
+            calculatorMock.Setup.Add(Arg.Any(), Arg.Any()).Returns(args => args.x + args.y);
+            calculatorMock.Setup.Subtract(Arg.Any(), Arg.Any()).Returns(args => args.a - args.b);
+            calculatorMock.Setup.Multiply(Arg.Any(), Arg.Any()).Returns(args => args.x * args.y);
+            calculatorMock.Setup.Divide(Arg.Any(), Arg.Any()).Returns(args => args.a / args.b);
+
+            Assert.Equal(4, calculatorMock.MockedObject.Add(2, 2));
+            Assert.Equal(2, calculatorMock.MockedObject.Subtract(4, 2));
+            Assert.Equal(4, calculatorMock.MockedObject.Multiply(2, 2));
+            Assert.Equal(2, calculatorMock.MockedObject.Divide(4, 2));
         }
     }
 }


### PR DESCRIPTION
### Context
This pull request addresses an issue in the code generation process for interfaces with overloaded methods. The current implementation does not correctly handle the creation of the storing bags, due to the method `GetUniqueMethodName()` returning a to generic name.

```
void Accept(ISymbolVisitor visitor);      // GetUniqueMethodName() returns Accept_ISymbolVisitor
T Accept<T>(ISymbolVisitor<T> visitor);   // GetUniqueMethodName() returns Accept_ISymbolVisitor 

leading to:

9> error CS0102: The type 'ICalculatorMockSetup' already contains a definition for 'Accept_ISymbolVisitorBagStore'
9> error CS0102: The type 'ICalculatorMockSetup.ICalculatorMockCallTracker' already contains a definition for 'Accept_ISymbolVisitorCallStore'

```

### Changes Made
- **Refactored `GetUniqueMethodName` Method**:
  - Keep default behavior for `ArgCollectionName` creation.

- **Added `GetUniqueStoreName` Method**:
  - This method handles creation of a more specified name for the bags.

- **Updated Unit Tests**:
  - Added two new test interfaces `ISymbolVisitor`.
  - Added two overloaded methods to validate the behavior of the refactored code.

This PR implements the second feature, which depends on the changes made in PR #36 (fix-interface-inheritance). Please review and merge PR #36 before moving on to this one.
